### PR TITLE
Add an endpoint for proxying remote Icecast status

### DIFF
--- a/api/streams/urls.py
+++ b/api/streams/urls.py
@@ -2,5 +2,5 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^([-a-zA-Z0-9_])/status$', views.get_stream_status)
+    url(r'^([-a-zA-Z0-9_]+)/status$', views.get_stream_status)
 ]

--- a/api/streams/urls.py
+++ b/api/streams/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import url
+from . import views
+
+urlpatterns = [
+    url(r'^([-a-zA-Z0-9_])/status$', views.get_stream_status)
+]

--- a/api/streams/views.py
+++ b/api/streams/views.py
@@ -1,12 +1,12 @@
 from api.streams.models import StreamConfiguration
-from django.http import HttpResponse
+from django.http import JsonResponse
 from django.http.request import HttpRequest
 import requests
 
 def get_stream_status(request: HttpRequest, stream_slug: str):
     stream = StreamConfiguration.objects.get(slug=stream_slug)
 
-    r = requests.get(f'http://{stream.host}:{stream.port}/status-json.xsl')
+    r = requests.get('http://{stream.host}:{stream.port}/status-json.xsl'.format(stream=stream))
     r.raise_for_status()
 
-    return HttpResponse(r.json())
+    return JsonResponse(r.json())

--- a/api/streams/views.py
+++ b/api/streams/views.py
@@ -6,7 +6,7 @@ import requests
 def get_stream_status(request: HttpRequest, stream_slug: str):
     stream = StreamConfiguration.objects.get(slug=stream_slug)
 
-    r = requests.get('http://{stream.host}:{stream.port}/status-json.xsl'.format(stream=stream))
+    r = requests.get('http://{stream.host}:{stream.port}/status-json.xsl'.format(stream=stream), timeout=5)
     r.raise_for_status()
 
     return JsonResponse(r.json())

--- a/api/streams/views.py
+++ b/api/streams/views.py
@@ -1,3 +1,12 @@
-from django.shortcuts import render
+from api.streams.models import StreamConfiguration
+from django.http import HttpResponse
+from django.http.request import HttpRequest
+import requests
 
-# Create your views here.
+def get_stream_status(request: HttpRequest, stream_slug: str):
+    stream = StreamConfiguration.objects.get(slug=stream_slug)
+
+    r = requests.get(f'http://{stream.host}:{stream.port}/status-json.xsl')
+    r.raise_for_status()
+
+    return HttpResponse(r.json())

--- a/config/urls.py
+++ b/config/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
 
     # User management
     url(r'^users/', include('api.users.urls', namespace='users')),
+    url(r'^streams/', include('api.streams.urls', namespace='streams')),
     url(r'^accounts/', include('allauth.urls')),
     url(r'^graphql', csrf_exempt(GraphQLWithAuthView.as_view(graphiql=True))),
     url(r'^cms/', include(wagtailadmin_urls)),


### PR DESCRIPTION
While testing upcoming frontend changes, I realised the original plan of issuing requests to Icecast servers had a flaw - Icecast provides no CORS headers, so the browser rejects the response. To fix this, I've introduced an endpoint to the API: `/streams/:slug/status`, which takes a stream slug as input and spits out the JSON returned from Icecast's `/status-json.xsl` endpoint.

I chose to add a standard endpoint as I did not feel it was appropriate to add an object to the GraphQL graph, as this data isn't part of the schema.