### PR TITLE
Install django-extensions in production

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,6 +19,7 @@ django-crispy-forms==1.6.1
 
 # Models
 django-model-utils==3.1.1
+django-extensions==1.9.9
 
 # Images
 Pillow==4.1.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -5,7 +5,6 @@ coverage==4.5.1
 django-coverage-plugin==1.5.0
 
 Sphinx==1.6.1
-django-extensions==1.9.9
 Werkzeug==0.12.2
 django-test-plus==1.0.22
 factory-boy==2.8.1


### PR DESCRIPTION
turns out we need this module everywhere if we use its AutoSlugField, lol